### PR TITLE
Support Season Searches in Torrentio

### DIFF
--- a/Custom/torrentio.yml
+++ b/Custom/torrentio.yml
@@ -42,13 +42,13 @@ search:
   headers:
     User-Agent: ["Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0"]
   paths:
-    - path: "{{ if .Query.IMDBID }}{{ .Config.default_opts }}|realdebrid={{ .Config.rd_key }}|debridoptions=nodownloadlinks/stream/movie/{{ .Query.IMDBID }}.json{{ else }}providers=rarbg,1337x|sort=size|qualityfilter=brremux,hdrall,dolbyvision,4k,720p,480p,other,scr,cam,unknown|sort=size|limit=1|realdebrid={{ .Config.rd_key }}|debridoptions=nodownloadlinks/stream/movie/tt0137523.json{{ end }}"
+    - path: "{{ .Config.default_opts }}|realdebrid={{ .Config.rd_key }}|debridoptions=nodownloadlinks/stream/movie/{{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}tt0137523{{ end }}.json"
       method: get
       response:
         type: json
         noResultsMessage: '"streams": []'
       categories: [Movies]
-    - path: "{{ if and .Query.Season .Query.Ep }}{{ .Config.default_opts }}|realdebrid={{ .Config.rd_key }}|debridoptions=nodownloadlinks/stream/series/tt{{ .Query.IMDBIDShort }}:0{{ .Query.Season }}:0{{ .Query.Ep }}.json{{ else }}providers=rarbg,1337x|sort=size|qualityfilter=brremux,hdrall,dolbyvision,4k,720p,480p,other,scr,cam,unknown|limit=1|realdebrid={{ .Config.rd_key }}|debridoptions=nodownloadlinks/stream/series/tt1632701:1:1.json{{ end }}"
+    - path: "{{ .Config.default_opts }}|realdebrid={{ .Config.rd_key }}|debridoptions=nodownloadlinks/stream/series/{{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}tt1632701{{ end }}:{{ if .Query.Season }}{{ .Query.Season }}{{ else }}1{{ end }}:{{ if .Query.Ep }}{{ .Query.Ep }}{{ else }}1{{ end }}.json"
       method: get
       response:
         type: json


### PR DESCRIPTION
By setting fallbacks per-field, we can support season searches (by defaulting to episode 1), while still supporting the Prowlarr test by falling back to Fight Club or Suits for the "base" query.