### PR TITLE
Remove filter from size.

### DIFF
--- a/Custom/comet.yml
+++ b/Custom/comet.yml
@@ -95,9 +95,6 @@ search:
           args: "/playback/([^/]+)"
     size:
       text: "{{ if .Result.indexer_is_torrentio }}{{ .Result.torrentio_size }}{{ else }}{{ .Result.torrentSize }}{{ end }}"
-      filters:
-        - name: default
-          args: "{{ .Result.torrentSize }}"
     quality:
       selector: name
       filters:


### PR DESCRIPTION
The 'default' filter does not exist, see https://wiki.servarr.com/en/prowlarr/cardigann-yml-definition#filters.

This causes the following error to be spammed in prowlarr events for every search:

```
CardigannIndexer (comet): Unsupported field filter: default
```

The variable substition in the text property works without any filter, see the category property as example.

Tested on my own instance, removing these lines has prevented any further unsupported field filter errors from appearing in prowlarr events.