### PR TITLE
Fix TV api call torbox.yml

### DIFF
--- a/Custom/torbox.yml
+++ b/Custom/torbox.yml
@@ -52,7 +52,7 @@ search:
         type: json
         noResultsMessage: "Could not find metadata. Please try again later."
       categories: [Movies]
-    - path: "{{ if .Query.IMDBID }}torrents/imdb:{{ .Query.IMDBID }}{{else}}torrents/imdb:{{ .Config.validate_imdb_tv }}{{ end }}?Season:{{ if .Query.Season }}{{ .Query.Season }}{{ else }}1{{ end }}?Episode:{{ if .Query.Ep }}{{ .Query.Ep }}{{ else }}1{{ end }}"
+    - path: "{{ if .Query.IMDBID }}torrents/imdb:{{ .Query.IMDBID }}{{else}}torrents/imdb:{{ .Config.validate_imdb_tv }}{{ end }}?season={{ if .Query.Season }}{{ .Query.Season }}{{ else }}1{{ end }}&episode={{ if .Query.Ep }}{{ .Query.Ep }}{{ else }}1{{ end }}"
       method: get
       response:
         type: json


### PR DESCRIPTION
Fix for the API call for TV search. Now it gets the correct episodes when searching for specific ones.

Torbox api docs: https://www.postman.com/wamy-dev/torbox/request/sgwtp70/get-torrent-data