### PR TITLE
Remove unnecessary user-agent field from Comet indexer (reasons in description)

### DIFF
--- a/Custom/comet.yml
+++ b/Custom/comet.yml
@@ -51,11 +51,6 @@ settings:
     label: IMDB ID TV show to use for Sonarr validation (must exist in indexer)
     default: "tt9288030"
 search:
-  headers:
-    User-Agent:
-      [
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0",
-      ]
   paths:
     - path: /{{ .Config.b64config }}/stream/movie/{{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ .Config.validate_imdb_movie }}{{ end }}.json
       method: get


### PR DESCRIPTION
Hey @Pukabyte :)

This PR simply proposes removing the unnecessary Mozilla user-agent from the Comet indexer, which bypasses ElfHosted's rate-limit that separates automated scrapers from casual Stremio users, on https://comet.elfhosted.com

The intention of Elfhosted's rate-limit to protect the resources of https://comet.elfhosted.com from being overloaded by automated scraping, such that the primary function of the addon (*to serve Stremio on-demand users*) is preserved. 

Prowlarr users wanting to use automated scraping are instead recommended to use https://zilean.elfhosted.com, which is extremely efficient and thus, un-ratelimited, and contains all DMM publicly-shared hashes, as well as the StremThru cache. 

(*If you need more indexers, it'd be more efficient to add them to your own Prowlarr, rather than trying to scrape the public ElfHosted Comet*)

Thanks! :)
D