### PR TITLE
Fix infohash must be 40 characters error

### DIFF
--- a/Custom/torrentio.yml
+++ b/Custom/torrentio.yml
@@ -110,7 +110,7 @@ search:
       selector: url
       filters:
         - name: split
-          args: ["/", 5]
+          args: ["/", 6]
     seeders:
       selector: title
       filters:


### PR DESCRIPTION
The infohash path segment moved, causing the extracted value to be incorrect. This resulted in the error: "InfoHash must be 40 characters long". Updated split filter arg from 5 to 6 to correctly extract the infohash. Addresses issue #80  