### PR TITLE
Refactor torrentio.yml settings and paths

### DIFF
--- a/Custom/torrentio.yml
+++ b/Custom/torrentio.yml
@@ -23,16 +23,10 @@ caps:
   allowrawsearch: false
 
 settings:
-  - name: opt_label
-    type: info
-    label: Torrentio Options are Required
   - name: default_opts
     type: text
     label: Torrentio Options
     default: "providers=yts,eztv,rarbg,1337x,thepiratebay,kickasstorrents,torrentgalaxy,magnetdl,horriblesubs,nyaasi|sort=qualitysize|qualityfilter=480p,scr,cam"
-  - name: rdkey_label
-    type: info
-    label: Real-Debrid API Key Required
   - name: debrid_provider_key
     type: text
     label: Debrid provider API Key
@@ -40,44 +34,38 @@ settings:
   - name: debrid_provider
     type: select
     label: Debrid provider
-    default: realdebrid
+    default: none
     options:
+      none: None
       realdebrid: Real-Debrid
       alldebrid: AllDebrid
       premiumize: Premiumize
       debridlink: Debridlink
       offcloud: Offcloud
       putio: Put.io
-  - name: validation_label
-    type: info
-    label: Validation settings optional
-  - name: validate_imdb_movie_label
-    type: info
-    label: The following help to validate an indexer in Sonarr by confirming that the show returns results
   - name: validate_imdb_movie
     type: text
     label: IMDB ID of Movie to use for Radarr validation (must exist in indexer)
-    default: "tt0137523"  # Fight Club
-  - name: validate_imdb_tv_label
-    type: info
-    label: The following help to validate an indexer in Sonarr by confirming that the show returns results
+    default: "tt0137523" # Fight Club
   - name: validate_imdb_tv
     type: text
     label: IMDB ID TV show to use for Sonarr validation (must exist in indexer)
-    default: "tt9288030"  # Reacher S02E01
-
+    default: "tt9288030" # Reacher S02E01
 
 search:
   headers:
-    User-Agent: ["Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0"]
+    User-Agent:
+      [
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0",
+      ]
   paths:
-    - path: "{{ if .Query.IMDBID }}{{ .Config.default_opts }}|{{ .Config.debrid_provider }}={{ .Config.debrid_provider_key }}/stream/movie/{{ .Query.IMDBID }}.json{{ else }}providers=rarbg,1337x|sort=size|qualityfilter=brremux,hdrall,dolbyvision,4k,720p,480p,other,scr,cam,unknown|sort=size|limit=1|{{ .Config.debrid_provider }}={{ .Config.debrid_provider_key }}/stream/movie/{{ .Config.validate_imdb_movie }}.json{{ end }}"
+    - path: "{{ if .Query.IMDBID }}{{ .Config.default_opts }}|{{ .Config.debrid_provider }}={{ .Config.debrid_provider_key }}/stream/movie/{{ .Query.IMDBID }}.json{{ else }}providers=rarbg,1337x|sort=size|qualityfilter=brremux,hdrall,dolbyvision,4k,720p,480p,other,scr,cam,unknown|{{ .Config.debrid_provider }}={{ .Config.debrid_provider_key }}/stream/movie/{{ .Config.validate_imdb_movie }}.json{{ end }}"
       method: get
       response:
         type: json
         noResultsMessage: '"streams": []'
       categories: [Movies]
-    - path: "{{ if .Query.IMDBID }}{{ .Config.default_opts }}{{else}}providers=rarbg,1337x|sort=size|qualityfilter=brremux,hdrall,dolbyvision,4k,720p,480p,other,scr,cam,unknown|limit=1{{ end }}|{{ .Config.debrid_provider }}={{ .Config.debrid_provider_key }}/stream/series/{{ if .Query.IMDBID }}{{ .Query.IMDBID}}{{ else }}{{ .Config.validate_imdb_tv }}{{ end }}:{{ if .Query.Season }}{{ .Query.Season }}{{ else }}1{{ end }}:{{ if .Query.Ep }}{{ .Query.Ep }}{{ else }}1{{ end }}.json"
+    - path: "{{ if .Query.IMDBID }}{{ .Config.default_opts }}{{else}}providers=rarbg,1337x|sort=size|qualityfilter=brremux,hdrall,dolbyvision,4k,720p,480p,other,scr,cam,unknown{{ end }}|{{ .Config.debrid_provider }}={{ .Config.debrid_provider_key }}/stream/series/{{ if .Query.IMDBID }}{{ .Query.IMDBID}}{{ else }}{{ .Config.validate_imdb_tv }}{{ end }}:{{ if .Query.Season }}{{ .Query.Season }}{{ else }}1{{ end }}:{{ if .Query.Ep }}{{ .Query.Ep }}{{ else }}1{{ end }}.json"
       method: get
       response:
         type: json
@@ -107,17 +95,16 @@ search:
     category:
       text: "{{ if .Result.category_is_tv_show }}TV{{ else }}Movies{{ end }}"
     infohash:
-      selector: url
-      filters:
-        - name: split
-          args: ["/", 6]
+      selector: infoHash
     seeders:
       selector: title
       filters:
         - name: regexp
-          args: "(\\uD83D\\uDC64 \\d+)"
+          args: "👤 (\\d+)"
+    leechers:
+      text: "0"
     size:
       selector: title
       filters:
         - name: regexp
-          args: "\\b(\\d+(?:\\.\\d+)? [MG]B)\\b"
+          args: "💾 (\\d+(?:\\.\\d+)? [KMGT]B)"


### PR DESCRIPTION
Add none option by default for the debrid service

Fixed infohash selector: Changed from selector: url to selector: infoHash

If debrid is set, maybe url is returned?
Not sure how to make this optional.

File size seems incorrect its the first episode size on season packs not size of entire torrent.