### PR TITLE
fix(comet): safely handle cases where fields are missing

### DIFF
--- a/Custom/comet.yml
+++ b/Custom/comet.yml
@@ -67,7 +67,7 @@ search:
       categories: [TV]
 
   rows:
-    selector: streams
+    selector: streams:has(behaviorHints)
     missingAttributeEqualsNoResults: true
 
   fields:


### PR DESCRIPTION
Sometimes Comet appends a stream which contains messages like:

```json
  "streams": [
    {
      "name": "[🔄] Comet",
      "description": "First search for this media - More results will be available in a few seconds...",
      "url": "https://comet.example.com"
    }
```

This breaks the indexer at the moment, as it's missing required fields:

```---> System.Exception: Selector "behaviorHints.videoSize" didn't match JSON content```

This'll mark the indexer as disabled for a bit, and makes you wait or re-test it to re-enable it, which is annoying.

This PR fixes this issue by only processing streams that contain a `behaviorHints` entry.