### PR TITLE
fix(comet): extract infohash from bingeGroup instead of playback URL

### DIFF
--- a/Custom/comet.yml
+++ b/Custom/comet.yml
@@ -101,10 +101,10 @@ search:
     category:
       text: "{{ if .Result.category_is_tv_show }}TV{{ else }}Movies{{ end }}"
     infohash:
-      selector: url
+      selector: behaviorHints.bingeGroup
       filters:
-        - name: regexp
-          args: "/playback/([^/]+)"
+        - name: split
+          args: ["|", 2]
     size:
       text: "{{ if .Result.torrent_size }}{{ .Result.torrent_size }}{{ else }}{{ .Result.torrentio_size }}{{ end }}"
     quality:
@@ -125,3 +125,4 @@ search:
       text: "30"
     leechers:
       text: "0"
+


### PR DESCRIPTION
The `infohash` field was extracting from the playback URL using `/playback/([^/]+)`, which contains an encrypted token, not a valid 40-char infohash. The actual infohash is in `behaviorHints.bingeGroup` (e.g. "comet|debrid|hash"). Changed to split on `|` and take index 2.