### PR TITLE
Aeres-u99 | Replacing infoHash selector from json to the one from URL

### DIFF
--- a/Custom/torrentio.yml
+++ b/Custom/torrentio.yml
@@ -105,7 +105,10 @@ search:
     category:
       text: "{{ if .Result.category_is_tv_show }}TV{{ else }}Movies{{ end }}"
     infohash:
-      selector: infoHash
+      selector: url
+      filters:
+        - name: regexp
+          args: "/([a-f0-9]{40})"
     seeders:
       selector: title
       filters:


### PR DESCRIPTION
Bug:

```
Unable to connect to indexer, check the log above the ValidationFailure for more details. Error while parsing field=infohash, selector=infoHash, value=<null>: Selector "infoHash" didn't match JSON content
```

Resolution:

Fetched url from torrentio has the relevant infoHash, which allows us to use that instead of relying on json selector