### PR TITLE
Fix StremThru TV IMDb searches

### DIFF
--- a/Custom/stremthru.yml
+++ b/Custom/stremthru.yml
@@ -31,7 +31,7 @@ caps:
   modes:
     search: [q]
     movie-search: [q, imdbid]
-    tv-search: [q, season, ep]
+    tv-search: [q, season, ep, imdbid]
   allowrawsearch: false
 
 settings:
@@ -53,7 +53,9 @@ search:
         noResultsMessage: '{"data":{"items":[],"total_items":0}}'
       categories: [Movies]
 
-    - path: /v0/torrents?no_missing_size=1&sid={{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ .Config.validate_imdb_tv }}{{ end }}:{{ if .Query.Season }}{{ .Query.Season }}{{ else }}1{{ end }}:{{ if .Query.Ep }}{{ .Query.Ep }}{{ else }}1{{ end }}"
+    # Sonarr can retry TV searches without an IMDb ID. Use a known-empty ID
+    # for those real searches so they cannot return the validation series.
+    - path: /v0/torrents?no_missing_size=1&sid={{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ end }}{{ if and .Query.Season (eq .Query.IMDBID .False) }}tt0000000{{ else }}{{ end }}{{ if and (eq .Query.IMDBID .False) (eq .Query.Season .False) }}{{ .Config.validate_imdb_tv }}{{ else }}{{ end }}:{{ if .Query.Season }}{{ .Query.Season }}{{ else }}1{{ end }}:{{ if .Query.Ep }}{{ .Query.Ep }}{{ else }}1{{ end }}
       method: get
       response:
         type: json


### PR DESCRIPTION
## Summary

- declare `imdbid` in StremThru TV search capabilities
- remove the malformed trailing quote from the TV request path
- preserve the validation-series fallback only for validation requests
- fail closed with a known-empty IMDb ID when Sonarr retries a real TV search without an IMDb ID

## Why

Sonarr performs an IMDb-based TV search and may then retry with query/season/episode only. The existing definition does not advertise IMDb support, and its fallback sends the configured validation series (`tt3581920`) for those real searches. That returns unrelated *The Last of Us* releases and can leave Sonarr with `Unknown Series` results.

The conditions are deliberately independent and flat because Cardigann emits nested or `else if` template blocks literally in rendered URLs.

## Validation

- YAML parses successfully
- live Prowlarr rendered an IMDb request as `sid=tt14688458:3:2`
- live no-IMDb TV request rendered as `sid=tt0000000:7:9` and returned zero results with HTTP 200
- validation mode retains `validate_imdb_tv`
- Sonarr episode search returned no validation-series releases

The repository AJV command currently also fails on unmodified `search.fields.language`, which is unrelated to this change.